### PR TITLE
feat: add deceased field and visual indicator on tree nodes

### DIFF
--- a/prisma/migrations/20260303000000_add_deceased_to_person/migration.sql
+++ b/prisma/migrations/20260303000000_add_deceased_to_person/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Person" ADD COLUMN "deceased" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model Person {
   gender          Gender    @default(UNKNOWN)
   bio             String?
   profilePhotoUrl String?
+  deceased        Boolean   @default(false)
 
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt

--- a/src/app/api/persons/[id]/route.ts
+++ b/src/app/api/persons/[id]/route.ts
@@ -48,6 +48,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
       gender: body.gender,
       bio: body.bio,
       profilePhotoUrl: body.profilePhotoUrl,
+      deceased: body.deceased !== undefined ? body.deceased : undefined,
     },
   });
 

--- a/src/app/api/persons/route.ts
+++ b/src/app/api/persons/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
   if (!userId) return unauthorized();
 
   const body = await req.json();
-  const { treeId, firstName, lastName, birthDate, deathDate, birthPlace, gender, bio } = body;
+  const { treeId, firstName, lastName, birthDate, deathDate, birthPlace, gender, bio, deceased } = body;
 
   if (!treeId || !firstName || !lastName) {
     return err("treeId, firstName, and lastName are required");
@@ -49,6 +49,7 @@ export async function POST(req: NextRequest) {
       birthPlace,
       gender,
       bio,
+      deceased: deceased ?? false,
     },
   });
 

--- a/src/app/api/tree/[personId]/route.ts
+++ b/src/app/api/tree/[personId]/route.ts
@@ -18,7 +18,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ per
   // Fetch all persons in the tree (not deleted)
   const persons = await db.person.findMany({
     where: { treeId: rootPerson.treeId, deletedAt: null },
-    select: { id: true, firstName: true, lastName: true, birthDate: true, deathDate: true, profilePhotoUrl: true },
+    select: { id: true, firstName: true, lastName: true, birthDate: true, deathDate: true, profilePhotoUrl: true, deceased: true },
   });
 
   // Fetch all relationships in the tree
@@ -38,6 +38,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ per
       birthDate: p.birthDate,
       deathDate: p.deathDate,
       profilePhotoUrl: p.profilePhotoUrl,
+      deceased: p.deceased,
       isRoot: p.id === personId,
     },
   }));

--- a/src/components/person/PersonProfile.tsx
+++ b/src/components/person/PersonProfile.tsx
@@ -25,6 +25,7 @@ interface PersonWithRelations {
   bio: string | null;
   profilePhotoUrl: string | null;
   gender: string;
+  deceased: boolean;
   relationshipsAsA: { type: string; personB: RelatedPerson }[];
   relationshipsAsB: { type: string; personA: RelatedPerson }[];
   photoPersons: { photo: { id: string; url: string; caption: string | null } }[];
@@ -52,6 +53,8 @@ export default function PersonProfile({
   const router = useRouter();
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [deceased, setDeceased] = useState(person.deceased);
+  const [savingDeceased, setSavingDeceased] = useState(false);
 
   const backPath = linkBase === "/demo/person" ? "/demo" : "/tree";
 
@@ -73,6 +76,18 @@ export default function PersonProfile({
     ...person.relationshipsAsA.filter((r) => r.type === "SPOUSE_OF").map((r) => r.personB),
     ...person.relationshipsAsB.filter((r) => r.type === "SPOUSE_OF").map((r) => r.personA),
   ];
+
+  async function toggleDeceased(value: boolean) {
+    setSavingDeceased(true);
+    setDeceased(value);
+    await fetch(`${apiBase}/${person.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ deceased: value }),
+    });
+    setSavingDeceased(false);
+    router.refresh();
+  }
 
   async function setProfilePhoto(url: string) {
     await fetch(`${apiBase}/${person.id}`, {
@@ -143,6 +158,18 @@ export default function PersonProfile({
             {person.deathDate && <span>Died: {fmt(person.deathDate)}</span>}
             {person.birthPlace && <span>From: {person.birthPlace}</span>}
           </div>
+          {!isDemo && (
+            <label className="mt-3 inline-flex items-center gap-2 cursor-pointer text-sm text-stone-600">
+              <input
+                type="checkbox"
+                checked={deceased}
+                disabled={savingDeceased}
+                onChange={(e) => toggleDeceased(e.target.checked)}
+                className="h-4 w-4 rounded border-stone-300 accent-amber-500"
+              />
+              Deceased
+            </label>
+          )}
         </div>
       </div>
 

--- a/src/components/tree/AddPersonModal.tsx
+++ b/src/components/tree/AddPersonModal.tsx
@@ -37,6 +37,7 @@ export default function AddPersonModal({
   const [selectedRelatedPersonId, setSelectedRelatedPersonId] = useState(
     relatedPersonId ?? ""
   );
+  const [deceased, setDeceased] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [existingOtherParent, setExistingOtherParent] = useState<PersonSummary | null>(null);
@@ -49,6 +50,7 @@ export default function AddPersonModal({
       setBirthDate("");
       setBirthPlace("");
       setGender("UNKNOWN");
+      setDeceased(false);
       setRelationshipType(defaultRelationType ?? "child");
       setSelectedRelatedPersonId(relatedPersonId ?? "");
       setError(null);
@@ -110,6 +112,7 @@ export default function AddPersonModal({
           birthDate: birthDate || undefined,
           birthPlace: birthPlace.trim() || undefined,
           gender,
+          deceased,
         }),
       });
       const personJson = await personRes.json();
@@ -322,6 +325,17 @@ export default function AddPersonModal({
               <option value="OTHER">Other</option>
             </select>
           </div>
+
+          {/* Deceased */}
+          <label className="flex items-center gap-2.5 cursor-pointer rounded-lg border border-stone-200 bg-stone-50 px-3 py-2.5 text-sm text-stone-700 hover:bg-stone-100 transition-colors">
+            <input
+              type="checkbox"
+              checked={deceased}
+              onChange={(e) => setDeceased(e.target.checked)}
+              className="h-4 w-4 rounded border-stone-300 accent-amber-500"
+            />
+            Deceased
+          </label>
 
           {error && <p className="text-sm text-red-500">{error}</p>}
 

--- a/src/components/tree/PersonNode.tsx
+++ b/src/components/tree/PersonNode.tsx
@@ -11,6 +11,7 @@ type PersonNodeData = {
   birthDate?: string;
   deathDate?: string;
   profilePhotoUrl?: string;
+  deceased?: boolean;
   isRoot?: boolean;
   personLinkBase?: string;
   onAddParent?: () => void;
@@ -25,6 +26,7 @@ export default function PersonNode({ id, data }: NodeProps) {
     birthDate,
     deathDate,
     profilePhotoUrl,
+    deceased,
     isRoot,
     personLinkBase = "/person",
     onAddParent,
@@ -54,10 +56,16 @@ export default function PersonNode({ id, data }: NodeProps) {
       <Handle type="target" position={Position.Left} id="left" style={{ top: "50%" }} />
       <Link href={`${personLinkBase}/${id}`}>
         <div
-          className={`flex flex-col items-center gap-2 rounded-2xl border bg-white px-4 py-3 shadow-sm w-36 cursor-pointer hover:shadow-md transition-shadow ${
+          className={`relative overflow-hidden flex flex-col items-center gap-2 rounded-2xl border bg-white px-4 py-3 shadow-sm w-36 cursor-pointer hover:shadow-md transition-shadow ${
             isRoot ? "border-amber-400 ring-2 ring-amber-200" : "border-stone-200"
           }`}
         >
+          {deceased && (
+            <div
+              className="absolute top-0 right-0 w-5 h-5"
+              style={{ background: "linear-gradient(225deg, #000 50%, transparent 50%)" }}
+            />
+          )}
           {profilePhotoUrl ? (
             <Image
               src={profilePhotoUrl}


### PR DESCRIPTION
Implements #9: adds a `deceased` boolean field to the Person model and displays a black corner triangle on tree nodes for deceased people.

## Changes
- Prisma schema: `deceased Boolean @default(false)`
- Migration SQL file
- API routes (POST, PATCH, tree) updated
- AddPersonModal: Deceased checkbox
- PersonProfile: inline Deceased toggle
- PersonNode: black dog-ear triangle for deceased persons

Closes #9

Generated with [Claude Code](https://claude.ai/code)